### PR TITLE
feat: add quiz flow with scoring

### DIFF
--- a/app/quiz/page.tsx
+++ b/app/quiz/page.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import React, { useState } from 'react';
+import { scoreQuiz, QuizAnswers, QuizResult } from '../../lib/scoreQuiz';
+
+// Options for each quiz step
+const FAMILY_OPTIONS = ['citrus', 'floral', 'woody'];
+const INTENSITY_OPTIONS = ['light', 'medium', 'strong'];
+const TIME_OPTIONS = ['day', 'night'];
+const MOOD_OPTIONS = ['fresh', 'romantic', 'warm'];
+const SKIN_OPTIONS = ['dry', 'normal', 'oily'];
+
+export default function QuizPage() {
+  const [step, setStep] = useState(0);
+  const [answers, setAnswers] = useState<QuizAnswers>({
+    family: '',
+    intensity: '',
+    time: '',
+    mood: '',
+    skin: '',
+  });
+  const [result, setResult] = useState<QuizResult | null>(null);
+
+  const handleSelect = (field: keyof QuizAnswers, value: string) => {
+    const updated = { ...answers, [field]: value };
+    setAnswers(updated);
+    if (step < 4) {
+      setStep(step + 1);
+    } else {
+      const scored = scoreQuiz(updated);
+      setResult(scored);
+      setStep(step + 1);
+    }
+  };
+
+  const renderStep = () => {
+    switch (step) {
+      case 0:
+        return (
+          <Question
+            title="Select your favorite fragrance family"
+            options={FAMILY_OPTIONS}
+            onSelect={(v) => handleSelect('family', v)}
+          />
+        );
+      case 1:
+        return (
+          <Question
+            title="Preferred intensity"
+            options={INTENSITY_OPTIONS}
+            onSelect={(v) => handleSelect('intensity', v)}
+          />
+        );
+      case 2:
+        return (
+          <Question
+            title="When will you wear it?"
+            options={TIME_OPTIONS}
+            onSelect={(v) => handleSelect('time', v)}
+          />
+        );
+      case 3:
+        return (
+          <Question
+            title="What's your mood?"
+            options={MOOD_OPTIONS}
+            onSelect={(v) => handleSelect('mood', v)}
+          />
+        );
+      case 4:
+        return (
+          <Question
+            title="Skin type"
+            options={SKIN_OPTIONS}
+            onSelect={(v) => handleSelect('skin', v)}
+          />
+        );
+      default:
+        return renderResult();
+    }
+  };
+
+  const renderResult = () => {
+    if (!result || !result.scent) return <p>We couldn't find a match.</p>;
+    return (
+      <div>
+        <h2>We recommend: {result.scent.name}</h2>
+        <p>Confidence: {(result.confidence * 100).toFixed(0)}%</p>
+        <button onClick={() => console.log('add to cart', result.scent.id)}>
+          Add to Cart
+        </button>
+        <button onClick={() => console.log('view details', result.scent.id)}>
+          View Details
+        </button>
+        {result.confidence < 0.25 && (
+          <div>
+            <p>Not sure? Try our Discovery Set!</p>
+            <button onClick={() => console.log('add discovery set')}>Add Discovery Set</button>
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  return <div>{renderStep()}</div>;
+}
+
+interface QuestionProps {
+  title: string;
+  options: string[];
+  onSelect(value: string): void;
+}
+
+function Question({ title, options, onSelect }: QuestionProps) {
+  return (
+    <div>
+      <h2>{title}</h2>
+      {options.map((o) => (
+        <button key={o} onClick={() => onSelect(o)} style={{ display: 'block', margin: '8px 0' }}>
+          {o}
+        </button>
+      ))}
+    </div>
+  );
+}
+

--- a/lib/scoreQuiz.ts
+++ b/lib/scoreQuiz.ts
@@ -1,0 +1,83 @@
+export interface QuizAnswers {
+  family: string;
+  intensity: string;
+  time: string;
+  mood: string;
+  skin: string;
+}
+
+export interface Scent {
+  id: string;
+  name: string;
+  family: string;
+  intensity: string;
+  time: string;
+  mood: string;
+  skin: string;
+}
+
+export interface QuizResult {
+  scent: Scent | null;
+  confidence: number; // 0-1
+}
+
+// Example catalogue; in a real app this would likely come from an API or DB
+export const SCENTS: Scent[] = [
+  {
+    id: 's1',
+    name: 'Citrus Splash',
+    family: 'citrus',
+    intensity: 'light',
+    time: 'day',
+    mood: 'fresh',
+    skin: 'dry',
+  },
+  {
+    id: 's2',
+    name: 'Woodland Evening',
+    family: 'woody',
+    intensity: 'strong',
+    time: 'night',
+    mood: 'warm',
+    skin: 'oily',
+  },
+  {
+    id: 's3',
+    name: 'Floral Dream',
+    family: 'floral',
+    intensity: 'medium',
+    time: 'day',
+    mood: 'romantic',
+    skin: 'normal',
+  },
+];
+
+/**
+ * Scores the quiz answers against the scent catalogue and returns
+ * the best match and a confidence score (0-1).
+ *
+ * The confidence represents the percentage of matching attributes
+ * out of the total number of questions.
+ */
+export function scoreQuiz(answers: QuizAnswers, scents: Scent[] = SCENTS): QuizResult {
+  const totalQuestions = Object.keys(answers).length;
+  let best: Scent | null = null;
+  let bestScore = -1;
+
+  for (const scent of scents) {
+    let score = 0;
+    if (scent.family === answers.family) score++;
+    if (scent.intensity === answers.intensity) score++;
+    if (scent.time === answers.time) score++;
+    if (scent.mood === answers.mood) score++;
+    if (scent.skin === answers.skin) score++;
+
+    if (score > bestScore) {
+      bestScore = score;
+      best = scent;
+    }
+  }
+
+  const confidence = totalQuestions === 0 ? 0 : bestScore / totalQuestions;
+  return { scent: best, confidence };
+}


### PR DESCRIPTION
## Summary
- implement quiz page with five-step fragrance survey
- add scoring utility to recommend a scent and compute confidence

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ea0375d8832fa309361f00bb2018