### PR TITLE
feat: add subscribe API route

### DIFF
--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -1,0 +1,7 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  const { email } = await request.json();
+  console.log('Received subscription:', email);
+  return NextResponse.json({ success: true });
+}


### PR DESCRIPTION
## Summary
- add API route for POST /api/subscribe that logs email and returns success

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68c0ea075e60832f89c230daabee3dc1